### PR TITLE
Fix for results caching and a couple of concatenation errors.

### DIFF
--- a/src/API_v1_0.php
+++ b/src/API_v1_0.php
@@ -84,11 +84,11 @@ class API_v1_0 {
     $filename = $feed . "-" . $league . "-" . $season;
 
     if ( array_key_exists("gameid", $params[0]) ) {
-      $filename .= "-" + $params[0]["gameid"];
+      $filename .= "-" . $params[0]["gameid"];
     }
 
     if ( array_key_exists("fordate", $params[0]) ) {
-      $filename .= "-" + $params[0]["fordate"];
+      $filename .= "-" . $params[0]["fordate"];
     }
 
     $filename .= "." . $outputFormat;

--- a/src/API_v1_0.php
+++ b/src/API_v1_0.php
@@ -83,12 +83,12 @@ class API_v1_0 {
   private function __makeOutputFilename($league, $season, $feed, $outputFormat, ...$params) {
     $filename = $feed . "-" . $league . "-" . $season;
 
-    if ( array_key_exists("gameid", $params[0]) ) {
-      $filename .= "-" . $params[0]["gameid"];
+    if ( array_key_exists("gameid", $params[0][0]) ) {
+      $filename .= "-" . $params[0][0]["gameid"];
     }
 
-    if ( array_key_exists("fordate", $params[0]) ) {
-      $filename .= "-" . $params[0]["fordate"];
+    if ( array_key_exists("fordate", $params[0][0]) ) {
+      $filename .= "-" . $params[0][0]["fordate"];
     }
 
     $filename .= "." . $outputFormat;

--- a/src/API_v1_0.php
+++ b/src/API_v1_0.php
@@ -162,11 +162,11 @@ class API_v1_0 {
     }
 
     if ( !$this->__verifyFeedName($feed) ) {
-      throw new ErrorException("Unknown feed '" + $feed + "'.");
+      throw new ErrorException("Unknown feed '" . $feed . "'.");
     }
 
     if ( !$this->__verifyFormat($format) ) {
-      throw new ErrorException("Unsupported format '" + $format + "'.");
+      throw new ErrorException("Unsupported format '" . $format  "'.");
     }
 
     if ( $feed == 'current_season' ) {

--- a/src/API_v1_0.php
+++ b/src/API_v1_0.php
@@ -1,29 +1,20 @@
 <?php
-
 namespace MySportsFeeds;
-
 class API_v1_0 {
-
   private $auth;
-
   private $baseUrl;
   private $verbose;
   private $storeType;
   private $storeLocation;
   private $validFeeds;
   private $storeOutput;
-
   # Constructor
   public function __construct($verbose, $storeType = null, $storeLocation = null) {
-
     $this->auth = null;
-
-    $this->baseUrl = "https://api.mysportsfeeds.com/pull";
-
+    $this->baseUrl = "https://www.mysportsfeeds.com/api/feed/pull";
     $this->verbose = $verbose;
     $this->storeType = $storeType;
     $this->storeLocation = $storeLocation;
-
     $this->validFeeds = [
       'current_season',
       'cumulative_player_stats',
@@ -43,57 +34,47 @@ class API_v1_0 {
       'daily_dfs'
     ];
   }
-
   # Verify a feed
   private function __verifyFeedName($feed) {
     $isValid = false;
-
     foreach ( $this->validFeeds as $value ) {
       if ( $value == $feed ) {
         $isValid = true;
         break;
       }
     }
-
     return $isValid;
   }
-
   # Verify output format
   private function __verifyFormat($format) {
     $isValid = true;
-
     if ( $format != "json" and $format != "xml" and $format != "csv" ) {
       $isValid = false;
     }
-
     return $isValid;
   }
-
   # Feed URL (with only a league specified)
   private function __leagueOnlyUrl($league, $feed, $outputFormat, ...$params) {
     return $this->baseUrl . "/" . $league . "/" . $feed . "." . $outputFormat;
   }
-
   # Feed URL (with league + season specified)
   private function __leagueAndSeasonUrl($league, $season, $feed, $outputFormat, ...$params) {
     return $this->baseUrl . "/" . $league . "/" . $season . "/" . $feed . "." . $outputFormat;
   }
-
   # Generate the appropriate filename for a feed request
-  private function __makeOutputFilename($league, $season, $feed, $outputFormat, $cachekey) {
+  private function __makeOutputFilename($league, $season, $feed, $outputFormat, ...$params) {
     $filename = $feed . "-" . $league . "-" . $season;
-
-    if (isset($cachekey) && strlen($cachekey)) {
-      $filename .= "-" . $cachekey;
+    if ( array_key_exists("gameid", $params[0]) ) {
+      $filename .= "-" . $params[0]["gameid"];
     }
-
+    if ( array_key_exists("fordate", $params[0]) ) {
+      $filename .= "-" . $params[0]["fordate"];
+    }
     $filename .= "." . $outputFormat;
-
     return $filename;
   }
-
   # Save a feed response based on the store_type
-  private function __saveFeed($response, $league, $season, $feed, $outputFormat, $cachekey) {
+  private function __saveFeed($response, $league, $season, $feed, $outputFormat, ...$params) {
     # Save to memory regardless of selected method
     if ( $outputFormat == "json" ) {
       $this->storeOutput = (array) json_decode($response);
@@ -102,44 +83,33 @@ class API_v1_0 {
     } elseif ( $outputFormat == "csv" ) {
       $this->storeOutput = $response;
     }
-
     if ( $this->storeType == "file" ) {
       if ( ! is_dir($this->storeLocation) ) {
         mkdir($this->storeLocation, 0, true);
       }
-
-      $filename = $this->__makeOutputFilename($league, $season, $feed, $outputFormat, $cachekey);
-
+      $filename = $this->__makeOutputFilename($league, $season, $feed, $outputFormat, $params);
       file_put_contents($this->storeLocation . $filename, $response);
     }
   }
-
   # Indicate this version does support BASIC auth
   public function supportsBasicAuth() {
     return true;
   }
-
   # Establish BASIC auth credentials
   public function setAuthCredentials($username, $password) {
     $this->auth = ['username' => $username, 'password' => $password];
   }
-
   # Request data (and store it if applicable)
   public function getData($league = "", $season = "", $feed = "", $format = "", ...$kvParams) {
     if ( !$this->auth ) {
-      throw new \ErrorException("You must authenticate() before making requests.");
+      throw new ErrorException("You must authenticate() before making requests.");
     }
-
     $params = [];
-    $cachekey = '';
-
     # iterate over args and assign vars
     foreach ( $kvParams[0] as $kvPair ) {
       $pieces = explode("=", $kvPair);
-
       $key = trim($pieces[0]);
       $value = trim($pieces[1]);
-      
       if ( $key == 'league' ) {
         $league = $value;
       } elseif ( $key == 'season' ) {
@@ -152,47 +122,32 @@ class API_v1_0 {
         $params[$key] = $value;
       }
     }
-
     # add force=false parameter (helps prevent unnecessary bandwidth use)
     if ( ! array_key_exists("force", $params) ) {
       $params['force'] = 'false';
     }
-
-    if ( array_key_exists("gameid", $params) ) {
-      $cachekey = $params['gameid'];
-    }
-
-    if ( array_key_exists("fordate", $params) ) {
-      $cachekey = $params['fordate'];
-    }
     if ( !$this->__verifyFeedName($feed) ) {
-      throw new \ErrorException("Unknown feed '" . $feed . "'.");
+      throw new ErrorException("Unknown feed '" . $feed . "'.");
     }
-
     if ( !$this->__verifyFormat($format) ) {
-      throw new \ErrorException("Unsupported format '" . $format . "'.");
+      throw new ErrorException("Unsupported format '" . $format  "'.");
     }
-
     if ( $feed == 'current_season' ) {
       $url = $this->__leagueOnlyUrl($league, $feed, $format, $params);
     } else {
       $url = $this->__leagueAndSeasonUrl($league, $season, $feed, $format, $params);
     }
-
     $delim = "?";
     if ( strpos($url, '?') !== false ) {
       $delim = "&";
     }
-
     foreach ( $params as $key => $value ) {
       $url .= $delim . $key . "=" . $value;
       $delim = "&";
     }
-
     if ( $this->verbose ) {
-      print("Making API request to '" . $url . "' ... \n<br>");
+      print("Making API request to '" . $url . "' ... \n");
     }
-
     // Establish a curl handle for the request
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
@@ -203,34 +158,25 @@ class API_v1_0 {
     curl_setopt($ch, CURLOPT_HTTPHEADER, [
       "Authorization: Basic " . base64_encode($this->auth['username'] . ":" . $this->auth['password'])
     ]); // Authenticate using HTTP Basic with account credentials
-
     // Send the request & retrieve response
     $resp = curl_exec($ch);
-
     // Uncomment the following if you're having trouble:
     // print(curl_error($ch)); 
-
     // Get the response code and then close the curl handle
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
-
     $data = "";
-
     if ( $httpCode == 200 ) {
       if ( $this->storeType != null ) {
-        $this->__saveFeed($resp, $league, $season, $feed, $format, $cachekey);
+        $this->__saveFeed($resp, $league, $season, $feed, $format, $params);
       }
-
       $data = $this->storeOutput;
     } elseif ( $httpCode == 304 ) {
       if ( $this->verbose ) {
-        print("Data hasn't changed since last call.\n<br>");
+        print("Data hasn't changed since last call.\n");
       }
-
-      $filename = $this->__makeOutputFilename($league, $season, $feed, $format, $cachekey);
-
+      $filename = $this->__makeOutputFilename($league, $season, $feed, $format, $params);
       $data = file_get_contents($this->storeLocation . $filename);
-
       if ( $format == "json" ) {
         $this->storeOutput = (array) json_decode($data);
       } elseif ( $format == "xml" ) {
@@ -238,13 +184,10 @@ class API_v1_0 {
       } elseif ( $format == "csv" ) {
         $this->storeOutput = $data;
       }
-
       $data = $this->storeOutput;
     } else {
-      throw new \ErrorException("API call failed with response code: " . $httpCode);
+      throw new ErrorException("API call failed with response code: " . $httpCode);
     }
-
     return $data;
   }
-
 }

--- a/src/API_v1_0.php
+++ b/src/API_v1_0.php
@@ -83,12 +83,12 @@ class API_v1_0 {
   private function __makeOutputFilename($league, $season, $feed, $outputFormat, ...$params) {
     $filename = $feed . "-" . $league . "-" . $season;
 
-    if ( array_key_exists("gameid", $params[0][0]) ) {
-      $filename .= "-" . $params[0][0]["gameid"];
+    if ( array_key_exists("gameid", $params[0]) ) {
+      $filename .= "-" . $params[0]["gameid"];
     }
 
-    if ( array_key_exists("fordate", $params[0][0]) ) {
-      $filename .= "-" . $params[0][0]["fordate"];
+    if ( array_key_exists("fordate", $params[0]) ) {
+      $filename .= "-" . $params[0]["fordate"];
     }
 
     $filename .= "." . $outputFormat;


### PR DESCRIPTION
Results for boxscores were saving with generic file names, preventing individual boxscores from getting cached. Parameters were not being passed successfully.

Also fixed a couple of concatenation syntax errors.
