### PR TITLE
Update README composer "require" syntax replace "\" with "/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Free for Non-Commercial Use.
 Using composer, simply add it to the "require" section of your composer.json:
     
     "require": {
-        "mysportsfeeds\mysportsfeeds-php": ">=2.0.0"
+        "mysportsfeeds/mysportsfeeds-php": ">=2.0.0"
     }
 
 If you haven't signed up for API access, do so here [https://www.mysportsfeeds.com/index.php/register/](https://www.mysportsfeeds.com/index.php/register/)


### PR DESCRIPTION
composer complains about backslash (\) in composer.json file, "require" parm:

[Seld\JsonLint\ParsingException]                                                                                    
  "./composer.json" does not contain valid JSON                                                                       
  Parse error on line 4:                                                                                              
  ...: "^0.4.2",        "mysportsfeeds\myspo                                                                          
  ---------------------^                                                                                              
  Invalid string, it appears you have an unescaped backslash ...

Replace the "\" with "/".