### PR TITLE
Won't run due to php errors

### DIFF
--- a/src/API_v1_0.php
+++ b/src/API_v1_0.php
@@ -6,6 +6,9 @@ class API_v1_0 extends BaseApi {
 
     # Constructor
     public function __construct($version, $verbose, $storeType = null, $storeLocation = null) {
+
+        parent::__construct($version, $verbose, $storeType, $storeLocation);
+
         $this->validFeeds = [
 	  		'seasonal_games',
 		    'daily_games',
@@ -33,7 +36,7 @@ class API_v1_0 extends BaseApi {
         ];
     }
 
-    protected function __determineUrl($league, $season, $feed, $output, ...$params)
+    protected function __determineUrl($league, $season, $feed, $outputFormat, ...$kvParams)
     {
         if ( $feed == 'current_season' ) {
             return $this->baseUrl . "/" . $league . "/" . $feed . "." . $outputFormat;

--- a/src/API_v1_1.php
+++ b/src/API_v1_1.php
@@ -3,4 +3,10 @@
 namespace MySportsFeeds;
 
 class API_v1_1 extends API_v1_0 {
+
+    # Constructor
+    public function __construct($version, $verbose, $storeType = null, $storeLocation = null) {
+
+        parent::__construct($version, $verbose, $storeType, $storeLocation);
+    }
 }

--- a/src/API_v1_2.php
+++ b/src/API_v1_2.php
@@ -3,4 +3,10 @@
 namespace MySportsFeeds;
 
 class API_v1_2 extends API_v1_1 {
+
+    # Constructor
+    public function __construct($version, $verbose, $storeType = null, $storeLocation = null) {
+
+        parent::__construct($version, $verbose, $storeType, $storeLocation);
+    }
 }

--- a/src/API_v2_0.php
+++ b/src/API_v2_0.php
@@ -7,7 +7,7 @@ class API_v2_0 extends API_v1_2 {
     # Constructor
     public function __construct($version, $verbose, $storeType = null, $storeLocation = null) {
 
-		parent::__construct();
+		parent::__construct($version, $verbose, $storeType, $storeLocation);
 
         $this->validFeeds = [
 	  		'seasonal_games',
@@ -36,8 +36,24 @@ class API_v2_0 extends API_v1_2 {
         ];
     }
 
-    protected function __determineUrl($league, $season, $feed, $outputFormat, $params)
+    protected function __determineUrl($league, $season, $feed, $outputFormat, ...$kvParams)
     {
+        if ($this->verbose) {
+            echo "<br>" . __CLASS__ . "::" . __METHOD__ . "<pre>" . print_r($kvParams, true) . "</pre><br>";
+        }
+
+        # create associative array from ... optional params array
+        $params = []; 
+        foreach ( $kvParams as $kvPair ) { 
+            $pieces = explode("=", $kvPair);
+            if (count($pieces) <> 2) {
+              throw new \ErrorException("Optional parameter '{$kvPair}' is invalid, must be of form 'xxxx=yyyyyyy'");
+            }
+            $key = trim($pieces[0]);
+            $value = trim($pieces[1]);
+            $params[$key] = $value;
+        }   
+
         if ( $feed == 'seasonal_games' ) {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
@@ -49,7 +65,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "date") ) {
+	        if ( !array_key_exists("date", $params) ) {
 	            throw new \ErrorException("You must specify a 'date' param for this request.");
 	        }
 
@@ -59,7 +75,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "week") ) {
+	        if ( !array_key_exists("week", $params) ) {
 	            throw new \ErrorException("You must specify a 'week' param for this request.");
 	        }
 
@@ -76,7 +92,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "date") ) {
+	        if ( !array_key_exists("date", $params) ) {
 	            throw new \ErrorException("You must specify a 'date' param for this request.");
 	        }
 
@@ -86,7 +102,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "week") ) {
+	        if ( !array_key_exists("week", $params) ) {
 	            throw new \ErrorException("You must specify a 'week' param for this request.");
 	        }
 
@@ -103,7 +119,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "date") ) {
+	        if ( !array_key_exists("date", $params) ) {
 	            throw new \ErrorException("You must specify a 'date' param for this request.");
 	        }
 
@@ -113,7 +129,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "week") ) {
+	        if ( !array_key_exists("week", $params) ) {
 	            throw new \ErrorException("You must specify a 'week' param for this request.");
 	        }
 
@@ -130,7 +146,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "date") ) {
+	        if ( !array_key_exists("date", $params) ) {
 	            throw new \ErrorException("You must specify a 'date' param for this request.");
 	        }
 
@@ -140,7 +156,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "week") ) {
+	        if ( !array_key_exists("week", $params) ) {
 	            throw new \ErrorException("You must specify a 'week' param for this request.");
 	        }
 
@@ -150,7 +166,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "game") ) {
+	        if ( !array_key_exists("game", $params) ) {
 	            throw new \ErrorException("You must specify a 'game' param for this request.");
 	        }
 
@@ -160,7 +176,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "game") ) {
+	        if ( !array_key_exists("game", $params) ) {
 	            throw new \ErrorException("You must specify a 'game' param for this request.");
 	        }
 
@@ -170,7 +186,7 @@ class API_v2_0 extends API_v1_2 {
 	        if ( !$season ) {
 	            throw new \ErrorException("You must specify a season for this request.");
 	        }
-	        if ( !array_key_exists($params, "game") ) {
+	        if ( !array_key_exists("game", $params) ) {
 	            throw new \ErrorException("You must specify a 'game' param for this request.");
 	        }
 

--- a/src/MySportsFeeds.php
+++ b/src/MySportsFeeds.php
@@ -53,8 +53,13 @@ class MySportsFeeds {
   }
 
   # Request data (and store it if applicable)
-  public function getData($league, $season, $feed, $format, ...$params) {
-    return $this->apiInstance->getData($league, $season, $feed, $format, $params);
+  public function getData($league, $season, $feed, $format, ...$kvParams) {
+
+    if ($this->verbose) {
+      echo "<br>" . __CLASS__ . "::" . __METHOD__ . "<pre>" . print_r($kvParams, true) . "</pre><br>";
+    }
+
+    return $this->apiInstance->getData($league, $season, $feed, $format, ...$kvParams);
   }
 
 }


### PR DESCRIPTION
There are several errors in latest GitHub version (2.0.0 ?) which prevent the code from running successfully:
- all constructors in subclasses of BaseApi need to call the parent constructor or else some base class properties, which are only initialized in the base class, have no value when you try to refer to them in the subclasses.
- the inconsistent usage of the "optional parameters" feature (ellipsis token) between the method definitions and the method invocations causes problems, and makes it difficult to follow
- some trivial-to-fix errors and/or typos cause problems, such as invalid parms for array_key_exists(), and calling a parent constructor with an empty parmlist when the parent requires non-optional parms.