### PR TITLE
Update PHP wrapper version number to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Free for Non-Commercial Use.
 Using composer, simply add it to the "require" section of your composer.json:
     
     "require": {
-        "mysportsfeeds/mysportsfeeds-php": ">=2.0.0"
+        "mysportsfeeds/mysportsfeeds-php": ">=2.1.0"
     }
 
 If you haven't signed up for API access, do so here [https://www.mysportsfeeds.com/index.php/register/](https://www.mysportsfeeds.com/index.php/register/)

--- a/src/MySportsFeeds.php
+++ b/src/MySportsFeeds.php
@@ -9,25 +9,25 @@ use MySportsFeeds\API_v2_0;
 
 class MySportsFeeds {
 
-  public $buildVersion = "2.0.0";
+  public $buildVersion = "2.1.0"; // PHP Wrapper version
 
-  private $version;
+  private $api_version;
   private $verbose;
   private $storeType;
   private $storeLocation;
 
   private $apiInstance;
 
-  public function __construct($version = "1.2", $verbose = false, $storeType = "file",
+  public function __construct($api_version = "1.2", $verbose = false, $storeType = "file",
                               $storeLocation = "results/") {
 
     $this->__verifyStore($storeType, $storeLocation);
 
-    $this->version = $version;
+    $this->api_version = $api_version;
     $this->verbose = $verbose;
     $this->storeType = $storeType;
     $this->storeLocation = $storeLocation;
-    $this->apiInstance = ApiFactory::create($this->version, $this->verbose, $this->storeType, $this->storeLocation);
+    $this->apiInstance = ApiFactory::create($this->api_version, $this->verbose, $this->storeType, $this->storeLocation);
   }
 
   # Verify the type and location of the stored data
@@ -46,7 +46,7 @@ class MySportsFeeds {
   # Authenticate against the API (for v1.x, v2.x)
   public function authenticate($apikey, $password) {
     if ( !$this->apiInstance->supportsBasicAuth() ) {
-      throw new \ErrorException("BASIC authentication not supported for version " + $this->version);
+      throw new \ErrorException("BASIC authentication not supported for API version " + $this->api_version);
     }
 
     $this->apiInstance->setAuthCredentials($apikey, $password);


### PR DESCRIPTION
After the successful merge of previous Pull Request #14 (fixes to wrapper 2.0.0) to the project master branch, the wrapper version number 2.0.0 was never changed.

This Pull Request updates the wrapper version number to 2.1.0.

It also renames a couple variables to emphasize, for me at least, the distinction between the Wrapper version number and the API version number.

After merging this Pull Request, please create a new wrapper Release v2.1.0.