### PR TITLE
Ok6245 support api v2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Free for Non-Commercial Use.
 Using composer, simply add it to the "require" section of your composer.json:
     
     "require": {
-        "mysportsfeeds/mysportsfeeds-php": ">=2.1.0"
+        "mysportsfeeds/mysportsfeeds-php": ">=2.1.1"
     }
 
 If you haven't signed up for API access, do so here [https://www.mysportsfeeds.com/index.php/register/](https://www.mysportsfeeds.com/index.php/register/)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=7.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/API_v1_0.php
+++ b/src/API_v1_0.php
@@ -10,39 +10,25 @@ class API_v1_0 extends BaseApi {
         parent::__construct($version, $verbose, $storeType, $storeLocation);
 
         $this->validFeeds = [
-	  		'seasonal_games',
-		    'daily_games',
-		    'weekly_games',
-		    'seasonal_dfs',
-		    'daily_dfs',
-		    'weekly_dfs',
-		    'seasonal_player_gamelogs',
-		    'daily_player_gamelogs',
-		    'weekly_player_gamelogs',
-		    'seasonal_team_gamelogs',
-		    'daily_team_gamelogs',
-		    'weekly_team_gamelogs',
-		    'game_boxscore',
-		    'game_playbyplay',
-		    'game_lineup',
-		    'current_season',
-		    'player_injuries',
-		    'latest_updates',
-		    'seasonal_team_stats',
-		    'seasonal_player_stats',
-		    'seasonal_venues',
-		    'players',
-		    'seasonal_standings'
+            'cumulative_player_stats'  => ['season' => true,  'pathparms' => [], 'endpoint' => 'cumulative_player_stats'],
+            'full_game_schedule'       => ['season' => true,  'pathparms' => [], 'endpoint' => 'full_game_schedule'],
+            'daily_game_schedule'      => ['season' => true,  'pathparms' => [], 'endpoint' => 'daily_game_schedule'],
+            'daily_player_stats'       => ['season' => true,  'pathparms' => [], 'endpoint' => 'daily_player_stats'],
+            'game_boxscore'            => ['season' => true,  'pathparms' => [], 'endpoint' => 'game_boxscore'],
+            'game_playbyplay'          => ['season' => true,  'pathparms' => [], 'endpoint' => 'game_playbyplay'],
+            'scoreboard'               => ['season' => true,  'pathparms' => [], 'endpoint' => 'scoreboard'],
+            'game_startinglineup'      => ['season' => true,  'pathparms' => [], 'endpoint' => 'game_startinglineup'],
+            'player_gamelogs'          => ['season' => true,  'pathparms' => [], 'endpoint' => 'player_gamelogs'],
+            'team_gamelogs'            => ['season' => true,  'pathparms' => [], 'endpoint' => 'team_gamelogs'],
+            'active_players'           => ['season' => true,  'pathparms' => [], 'endpoint' => 'active_players'],
+            'overall_team_standings'   => ['season' => true,  'pathparms' => [], 'endpoint' => 'overall_team_standings'],
+            'conference_team_standings'=> ['season' => true,  'pathparms' => [], 'endpoint' => 'conference_team_standings'],
+            'division_team_standings'  => ['season' => true,  'pathparms' => [], 'endpoint' => 'division_team_standings'],
+            'playoff_team_standings'   => ['season' => true,  'pathparms' => [], 'endpoint' => 'playoff_team_standings'],
+            'player_injuries'          => ['season' => true,  'pathparms' => [], 'endpoint' => 'player_injuries'],
+            'latest_updates'           => ['season' => true,  'pathparms' => [], 'endpoint' => 'latest_updates'],
+            'daily_dfs'                => ['season' => true,  'pathparms' => [], 'endpoint' => 'daily_dfs'],
+            'current_season'           => ['season' => false, 'pathparms' => [], 'endpoint' => 'current_season'],
         ];
     }
-
-    protected function __determineUrl($league, $season, $feed, $outputFormat, ...$kvParams)
-    {
-        if ( $feed == 'current_season' ) {
-            return $this->baseUrl . "/" . $league . "/" . $feed . "." . $outputFormat;
-        } else {
-            return $this->baseUrl . "/" . $league . "/" . $season . "/" . $feed . "." . $outputFormat;
-        }
-    }
-
 }

--- a/src/API_v2_0.php
+++ b/src/API_v2_0.php
@@ -10,231 +10,121 @@ class API_v2_0 extends API_v1_2 {
 		parent::__construct($version, $verbose, $storeType, $storeLocation);
 
         $this->validFeeds = [
-	  		'seasonal_games',
-		    'daily_games',
-		    'weekly_games',
-		    'seasonal_dfs',
-		    'daily_dfs',
-		    'weekly_dfs',
-		    'seasonal_player_gamelogs',
-		    'daily_player_gamelogs',
-		    'weekly_player_gamelogs',
-		    'seasonal_team_gamelogs',
-		    'daily_team_gamelogs',
-		    'weekly_team_gamelogs',
-		    'game_boxscore',
-		    'game_playbyplay',
-		    'game_lineup',
-		    'current_season',
-		    'player_injuries',
-		    'latest_updates',
-		    'seasonal_team_stats',
-		    'seasonal_player_stats',
-		    'seasonal_venues',
-		    'players',
-		    'seasonal_standings'
+            'seasonal_games' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'games',
+            ],
+            'daily_games' => [
+                'season'   => true, 
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'games',
+            ],
+            'weekly_games' => [
+                'season'   => true, 
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'games',
+            ],
+            'seasonal_dfs' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'dfs',
+            ],
+            'daily_dfs' => [
+                'season'   => true, 
+                'pathparms'=> ['date/date'], 
+                'endpoint' => 'dfs',
+            ],
+            'weekly_dfs' => [
+                'season'   => true, 
+                'pathparms'=> ['week/week'], 
+                'endpoint' => 'dfs',
+            ],
+            'seasonal_player_gamelogs' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'player_gamelogs',
+            ],
+            'daily_player_gamelogs' => [
+                'season'   => true, 
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'player_gamelogs',
+            ],
+            'weekly_player_gamelogs' => [
+                'season'   => true, 
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'player_gamelogs',
+            ],
+            'seasonal_team_gamelogs' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'team_gamelogs',
+            ],
+            'daily_team_gamelogs' => [
+                'season'   => true, 
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'team_gamelogs',
+            ],
+            'weekly_team_gamelogs' => [
+                'season'   => true, 
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'team_gamelogs',
+            ],
+            'game_boxscore' => [
+                'season'   => true, 
+                'pathparms'=> ['games/game'],
+                'endpoint' => 'boxscore',
+            ],
+            'game_playbyplay' => [
+                'season'   => true, 
+                'pathparms'=> ['games/game'],
+                'endpoint' => 'playbyplay',
+            ],
+            'game_lineup' => [
+                'season'   => true, 
+                'pathparms'=> ['games/game'],
+                'endpoint' => 'lineup',
+            ],
+            'current_season' => [
+                'season'   => false, 
+                'pathparms'=> [], 
+                'endpoint' => 'current_season',
+            ],
+            'player_injuries' => [
+                'season'   => false,
+                'pathparms'=> [],
+                'endpoint' => 'injuries',
+            ],
+            'latest_updates' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'latest_updates',
+            ],
+            'seasonal_team_stats' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'team_stats_totals',
+            ],
+            'seasonal_player_stats' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'player_stats_totals',
+            ],
+            'seasonal_venues' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'venues',
+            ],
+            'players' => [
+                'season'   => false,
+                'pathparms'=> [],
+                'endpoint' => 'players',
+            ],
+            'seasonal_standings' => [
+                'season'   => true, 
+                'pathparms'=> [], 
+                'endpoint' => 'standings',
+            ],
         ];
     }
-
-    protected function __determineUrl($league, $season, $feed, $outputFormat, ...$kvParams)
-    {
-        if ($this->verbose) {
-            echo "<br>" . __CLASS__ . "::" . __METHOD__ . "<pre>" . print_r($kvParams, true) . "</pre><br>";
-        }
-
-        # create associative array from ... optional params array
-        $params = []; 
-        foreach ( $kvParams as $kvPair ) { 
-            $pieces = explode("=", $kvPair);
-            if (count($pieces) <> 2) {
-              throw new \ErrorException("Optional parameter '{$kvPair}' is invalid, must be of form 'xxxx=yyyyyyy'");
-            }
-            $key = trim($pieces[0]);
-            $value = trim($pieces[1]);
-            $params[$key] = $value;
-        }   
-
-        if ( $feed == 'seasonal_games' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/games." . $outputFormat;
-
-        } else if ( $feed == 'daily_games' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("date", $params) ) {
-	            throw new \ErrorException("You must specify a 'date' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/date/" . $params["date"] . "/games." . $outputFormat;
-
-        } else if ( $feed == 'weekly_games' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("week", $params) ) {
-	            throw new \ErrorException("You must specify a 'week' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/week/" . $params["week"] . "/games." . $outputFormat;
-
-        } else if ( $feed == 'seasonal_dfs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/dfs." . $outputFormat;
-
-        } else if ( $feed == 'daily_dfs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("date", $params) ) {
-	            throw new \ErrorException("You must specify a 'date' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/date/" . $params["date"] . "/dfs." . $outputFormat;
-
-        } else if ( $feed == 'weekly_dfs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("week", $params) ) {
-	            throw new \ErrorException("You must specify a 'week' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/week/" . $params["week"] . "/dfs." . $outputFormat;
-
-        } else if ( $feed == 'seasonal_player_gamelogs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/player_gamelogs." . $outputFormat;
-
-        } else if ( $feed == 'daily_player_gamelogs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("date", $params) ) {
-	            throw new \ErrorException("You must specify a 'date' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/date/" . $params["date"] . "/player_gamelogs." . $outputFormat;
-
-        } else if ( $feed == 'weekly_player_gamelogs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("week", $params) ) {
-	            throw new \ErrorException("You must specify a 'week' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/week/" . $params["week"] . "/player_gamelogs." . $outputFormat;
-
-        } else if ( $feed == 'seasonal_team_gamelogs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/team_gamelogs." . $outputFormat;
-
-        } else if ( $feed == 'daily_team_gamelogs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("date", $params) ) {
-	            throw new \ErrorException("You must specify a 'date' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/date/" . $params["date"] . "/team_gamelogs." . $outputFormat;
-
-        } else if ( $feed == 'weekly_team_gamelogs' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("week", $params) ) {
-	            throw new \ErrorException("You must specify a 'week' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/week/" . $params["week"] . "/team_gamelogs." . $outputFormat;
-
-        } else if ( $feed == 'game_boxscore' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("game", $params) ) {
-	            throw new \ErrorException("You must specify a 'game' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/games/" . $params["game"] . "/boxscore." . $outputFormat;
-
-        } else if ( $feed == 'game_playbyplay' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("game", $params) ) {
-	            throw new \ErrorException("You must specify a 'game' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/games/" . $params["game"] . "/playbyplay." . $outputFormat;
-
-        } else if ( $feed == 'game_lineup' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-	        if ( !array_key_exists("game", $params) ) {
-	            throw new \ErrorException("You must specify a 'game' param for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/games/" . $params["game"] . "/lineup." . $outputFormat;
-
-        } else if ( $feed == 'current_season' ) {
-
-            return $this->baseUrl . "/" . $league . "/current_season." . $outputFormat;
-
-        } else if ( $feed == 'latest_updates' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/latest_updates." . $outputFormat;
-
-        } else if ( $feed == 'seasonal_team_stats' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/team_stats_totals." . $outputFormat;
-
-        } else if ( $feed == 'seasonal_player_stats' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/player_stats_totals." . $outputFormat;
-
-        } else if ( $feed == 'seasonal_venues' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/venues." . $outputFormat;
-
-        } else if ( $feed == 'seasonal_standings' ) {
-	        if ( !$season ) {
-	            throw new \ErrorException("You must specify a season for this request.");
-	        }
-
-            return $this->baseUrl . "/" . $league . "/" . $season . "/standings." . $outputFormat;
-
-        } else {
-            throw new \ErrorException("Unrecognized feed '" . $feed . "'.");
-        }
-
-    }
-
 }

--- a/src/API_v2_1.php
+++ b/src/API_v2_1.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace MySportsFeeds;
+
+class API_v2_1 extends API_v2_0 {
+
+    # Constructor
+    public function __construct($version, $verbose, $storeType = null, $storeLocation = null) {
+
+        parent::__construct($version, $verbose, $storeType, $storeLocation);
+
+        /**
+         * See BaseApi for syntax
+         */
+        $this->validFeeds = [
+            /* CORE */
+            'seasonal_games' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'games',
+            ],
+            'daily_games' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'games',
+            ],
+            'weekly_games' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'games',
+            ],
+            'current_season' => [
+                'season'   => false,
+                'pathparms'=> [],
+                'endpoint' => 'current_season',
+            ],
+            'latest_updates' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'latest_updates',
+            ],
+            'seasonal_venues' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'venues',
+            ],
+            /* STATS */
+            'daily_player_gamelogs' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'player_gamelogs',
+            ],
+            'weekly_player_gamelogs' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'player_gamelogs',
+            ],
+            'seasonal_player_gamelogs' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'player_gamelogs',
+            ],
+            'daily_team_gamelogs' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'team_gamelogs',
+            ],
+            'weekly_team_gamelogs' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'team_gamelogs',
+            ],
+            'seasonal_team_gamelogs' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'team_gamelogs',
+            ],
+            'seasonal_team_stats' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'team_stats_totals',
+            ],
+            'seasonal_player_stats' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'player_stats_totals',
+            ],
+            'seasonal_standings' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'standings',
+            ],
+            /* DETAILED */
+            'game_boxscore' => [
+                'season'   => true,
+                'pathparms'=> ['games/game'],
+                'endpoint' => 'boxscore',
+            ],
+            'game_playbyplay' => [
+                'season'   => true,
+                'pathparms'=> ['games/game'],
+                'endpoint' => 'playbyplay',
+            ],
+            'game_lineup' => [
+                'season'   => true,
+                'pathparms'=> ['games/game'],
+                'endpoint' => 'lineup',
+            ],
+            'player_injuries' => [
+                'season'   => false,
+                'pathparms'=> [],
+                'endpoint' => 'injuries',
+            ],
+            'players' => [
+                'season'   => false,
+                'pathparms'=> [],
+                'endpoint' => 'players',
+            ],
+            'injury_history' => [
+                'season'   => false,
+                'pathparms'=> [],
+                'endpoint' => 'injury_history',
+            ],
+            /* ODDS */
+            'daily_odds_gamelines' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'odds_gamelines',
+            ],
+            'weekly_odds_gamelines' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'odds_gamelines',
+            ],
+            'seasonal_odds_gamelines' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'odds_gamelines',
+            ],
+            'daily_odds_futures' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'odds_futures',
+            ],
+            /* PROJECTIONS */
+            'daily_player_gamelogs_projections' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'player_gamelogs_projections',
+            ],
+            'weekly_player_gamelogs_projections' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'player_gamelogs_projections',
+            ],
+            'daily_dfs_projections' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'dfs_projections',
+            ],
+            'weekly_dfs_projections' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'dfs_projections',
+            ],
+            'seasonal_player_stats_projections' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'player_stats_totals_projections',
+            ],
+            /* DFS */
+            'daily_dfs' => [
+                'season'   => true,
+                'pathparms'=> ['date/date'],
+                'endpoint' => 'dfs',
+            ],
+            'weekly_dfs' => [
+                'season'   => true,
+                'pathparms'=> ['week/week'],
+                'endpoint' => 'dfs',
+            ],
+            'seasonal_dfs' => [
+                'season'   => true,
+                'pathparms'=> [],
+                'endpoint' => 'dfs',
+            ],
+        ];
+    }
+}

--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -20,6 +20,9 @@ class ApiFactory
             case '2.0':
                 $apiVersion = new API_v2_0($version, $verbose, $storeType, $storeLocation);
                 break;
+            case '2.1':
+                $apiVersion = new API_v2_1($version, $verbose, $storeType, $storeLocation);
+                break;
             default:
                 $apiVersion = new BaseApi($version, $verbose, $storeType, $storeLocation);
                 break;

--- a/src/MySportsFeeds.php
+++ b/src/MySportsFeeds.php
@@ -2,75 +2,68 @@
 
 namespace MySportsFeeds;
 
-use MySportsFeeds\API_v1_0;
-use MySportsFeeds\API_v1_1;
-use MySportsFeeds\API_v1_2;
-use MySportsFeeds\API_v2_0;
-
 class MySportsFeeds {
 
-  public $buildVersion = "2.1.0"; // PHP Wrapper version
+    public $buildVersion = "2.1.1"; // PHP Wrapper version
+    
+    private $api_version;
+    private $verbose;
+    private $storeType;
+    private $storeLocation;
+    private $apiInstance;
 
-  private $api_version;
-  private $verbose;
-  private $storeType;
-  private $storeLocation;
-
-  private $apiInstance;
-
-  public function __construct($api_version = "1.2", $verbose = false, $storeType = "file",
+    public function __construct($api_version = "1.2", $verbose = false, $storeType = "file",
                               $storeLocation = "results/") {
 
-    $this->__verifyStore($storeType, $storeLocation);
+        $this->__verifyStore($storeType, $storeLocation);
 
-    $this->api_version = $api_version;
-    $this->verbose = $verbose;
-    $this->storeType = $storeType;
-    $this->storeLocation = $storeLocation;
-    $this->apiInstance = ApiFactory::create($this->api_version, $this->verbose, $this->storeType, $this->storeLocation);
-  }
-
-  # Verify the type and location of the stored data
-  private function __verifyStore($storeType, $storeLocation) {
-    if ($storeType !== null && $storeType != "file") {
-      throw new \ErrorException("Unrecognized storage type specified.  Supported values are: {null,'file'}");
+        $this->api_version = $api_version;
+        $this->verbose = $verbose;
+        $this->storeType = $storeType;
+        $this->storeLocation = $storeLocation;
+        $this->apiInstance = ApiFactory::create($this->api_version, $this->verbose, $this->storeType, $this->storeLocation);
     }
 
-    if ($storeType == "file") {
-      if ($storeLocation === null) {
-        throw new \ErrorException("Must specify a location for stored data.");
-      }
-    }
-  }
+    # Verify the type and location of the stored data
+    private function __verifyStore($storeType, $storeLocation) {
+        if ($storeType !== null && $storeType != "file") {
+            throw new \ErrorException("Unrecognized storage type specified.  Supported values are: {null,'file'}");
+        }
 
-  # Return an array of feed settings in this API version, indexed by feed name.
-  public function getFeedsList() {
-      return $this->apiInstance->getFeedsList();
-  }
-
-  # Get the HTTP response code from the most recent call to getData()
-  public function getHTTPCode() {
-      return $this->apiInstance->getHTTPCode();
-  }
-
-  # Get the URL used for the most recent call to getData()
-  public function getURL() {
-      return $this->apiInstance->getURL();
-  }
-
-  # Authenticate against the API (for v1.x, v2.x)
-  public function authenticate($apikey, $password) {
-    if (!$this->apiInstance->supportsBasicAuth()) {
-      throw new \ErrorException("BASIC authentication not supported for API version " + $this->api_version);
+        if ($storeType == "file") {
+            if ($storeLocation === null) {
+                throw new \ErrorException("Must specify a location for stored data.");
+            }
+        }
     }
 
-    $this->apiInstance->setAuthCredentials($apikey, $password);
-  }
+    # Return an array of feed settings in this API version, indexed by feed name.
+    public function getFeedsList() {
+        return $this->apiInstance->getFeedsList();
+    }
 
-  # Request data (and store it if applicable)
-  public function getData($league, $season, $feed, $format, ...$kvParams) {
+    # Get the HTTP response code from the most recent call to getData()
+    public function getHTTPCode() {
+        return $this->apiInstance->getHTTPCode();
+    }
 
-    return $this->apiInstance->getData($league, $season, $feed, $format, ...$kvParams);
-  }
+    # Get the URL used for the most recent call to getData()
+    public function getURL() {
+        return $this->apiInstance->getURL();
+    }
 
+    # Authenticate against the API (for v1.x, v2.x)
+    public function authenticate($apikey, $password) {
+        if (!$this->apiInstance->supportsBasicAuth()) {
+            throw new \ErrorException("BASIC authentication not supported for API version " + $this->api_version);
+        }
+
+        $this->apiInstance->setAuthCredentials($apikey, $password);
+    }
+
+    # Request data (and store it if applicable)
+    public function getData($league, $season, $feed, $format, ...$kvParams) {
+
+        return $this->apiInstance->getData($league, $season, $feed, $format, ...$kvParams);
+    }
 }

--- a/src/MySportsFeeds.php
+++ b/src/MySportsFeeds.php
@@ -32,12 +32,12 @@ class MySportsFeeds {
 
   # Verify the type and location of the stored data
   private function __verifyStore($storeType, $storeLocation) {
-    if ( $storeType != null and $storeType != "file" ) {
+    if ($storeType !== null && $storeType != "file") {
       throw new \ErrorException("Unrecognized storage type specified.  Supported values are: {null,'file'}");
     }
 
-    if ( $storeType == "file" ) {
-      if ( $storeLocation == null ) {
+    if ($storeType == "file") {
+      if ($storeLocation === null) {
         throw new \ErrorException("Must specify a location for stored data.");
       }
     }
@@ -48,9 +48,19 @@ class MySportsFeeds {
       return $this->apiInstance->getFeedsList();
   }
 
+  # Get the HTTP response code from the most recent call to getData()
+  public function getHTTPCode() {
+      return $this->apiInstance->getHTTPCode();
+  }
+
+  # Get the URL used for the most recent call to getData()
+  public function getURL() {
+      return $this->apiInstance->getURL();
+  }
+
   # Authenticate against the API (for v1.x, v2.x)
   public function authenticate($apikey, $password) {
-    if ( !$this->apiInstance->supportsBasicAuth() ) {
+    if (!$this->apiInstance->supportsBasicAuth()) {
       throw new \ErrorException("BASIC authentication not supported for API version " + $this->api_version);
     }
 

--- a/src/MySportsFeeds.php
+++ b/src/MySportsFeeds.php
@@ -43,6 +43,11 @@ class MySportsFeeds {
     }
   }
 
+  # Return an array of feed settings in this API version, indexed by feed name.
+  public function getFeedsList() {
+      return $this->apiInstance->getFeedsList();
+  }
+
   # Authenticate against the API (for v1.x, v2.x)
   public function authenticate($apikey, $password) {
     if ( !$this->apiInstance->supportsBasicAuth() ) {
@@ -54,10 +59,6 @@ class MySportsFeeds {
 
   # Request data (and store it if applicable)
   public function getData($league, $season, $feed, $format, ...$kvParams) {
-
-    if ($this->verbose) {
-      echo "<br>" . __CLASS__ . "::" . __METHOD__ . "<pre>" . print_r($kvParams, true) . "</pre><br>";
-    }
 
     return $this->apiInstance->getData($league, $season, $feed, $format, ...$kvParams);
   }


### PR DESCRIPTION
Add support to PHP wrapper for API v2.1.

Major updates for this proposed wrapper Release number 2.1.1:
- Require PHP version 7.4.0 or higher (current req is 5.6 which is unsupported and prevents using new PHP features) 
- Create new subclass API_v2_1 and add to ApiFactory
- Refactor the "validFeeds" array with additional data for each feed name to eliminate the duplication of feed names and the need to override BaseApi methods for each new API version. Retroactively applied new format to previous API feed lists. With this refactor, future API should not require any code changes except for creating a new subclass with the validFeeds array in the new format.
- I created the v2.1 feeds list as best I could from looking at the Online Documentation. Other wrappers were only a little helpful because they appear to differ from each other. I put the v2.1 feeds list in package order (CORE feeds, STATS feeds, etc). This helps with comparing feed lists using a DIFF type tool because looking at the Online Documentation is tedious and error-prone.
- revert the ellipsis ... token syntax in non-public method parmlists to ordinary array syntax for passing api variables/values. We're currently doing the conversion in 3 places where we could just do it once in BaseApi::getData().
- update the composer.json and README.md for new PHP version requirement and proposed new wrapper Release number 2.1.1
 
A housekeeping update:
I'm assuming that the general idea for wrapper Release numbers is to be representative of the highest API version that the wrapper supports.

The current, latest PHP wrapper (and Composer package) release number at this time is 2.1.0. That may have been a poor choice (by me) for that wrapper release number because although it contained many, many updates, it did not specifically address API v2.1. It only supported up to API v2.0.

This pull request contains updates to specifically support up to API V2.1. 

To get back to syncing the wrapper Release with the API version it contained, I'm proposing that this Pull Request is to create wrapper Release 2.1.1. Other updates for API v2.1 (if ever) can be given wrapper release numbers 2.1.x.

And when a future API top level version is created, say API v3.0, the wrapper to support that would get Release number 3.0.0.